### PR TITLE
More Cryptographically-Secure Salt Generator.

### DIFF
--- a/scrypt.php
+++ b/scrypt.php
@@ -53,6 +53,7 @@ class Password
 	}
 	// Use less-secure salt-generation method.
 	else {
+		error_log('php-scrypt warning: OpenSSL not installed!');
 		$salt = '';
 		$chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#%&*?';
 		$num = strlen($chars) - 1;


### PR DESCRIPTION
As seen on the [PHP: mt_rand](http://php.net/manual/en/function.mt-rand.php) page:

> [`mt_rand()`] does not generate cryptographically secure values, and should not be used for cryptographic purposes. If you need a cryptographically secure value, consider using `openssl_random_pseudo_bytes()` instead.

This pull request implements `openssl_random_pseudo_bytes()` for salt generation.
