### PR TITLE
Fixed string zero termination

### DIFF
--- a/php_scrypt.c
+++ b/php_scrypt.c
@@ -171,8 +171,10 @@ PHP_FUNCTION(scrypt)
         hex = (unsigned char*) emalloc(keyLength * 2 + 1);
         php_hash_bin2hex(hex, buf, keyLength);
         efree(buf);
+        hex[keyLength*2] = '\0';
         RETURN_STRINGL(hex, keyLength * 2, 0);
     } else {
+        buf[keyLength] = '\0';
         RETURN_STRINGL(buf, keyLength, 0);
     }
 }


### PR DESCRIPTION
Added string zero termination in scrypt
to remove "Warning: String is not zero-terminated" in debug php build
