### PR TITLE
Fix memory exhaustion error for tests

### DIFF
--- a/tests/vectors.phpt
+++ b/tests/vectors.phpt
@@ -2,6 +2,8 @@
 Test scrypt KDF using test vectors.
 --SKIPIF--
 <?php if (!extension_loaded("scrypt")) print "skip"; ?>
+--INI--
+memory_limit=2G
 --FILE--
 <?php 
 echo scrypt("", "", 16, 1, 1, 64) . "\n";


### PR DESCRIPTION
The last KDF test causes a large amount of memory to be used, sometimes resulting in a fatal error. This sets the memory limit properly.

Fixes #17 
