### PR TITLE
Fixed syntax error and redundant check

### DIFF
--- a/scrypt.php
+++ b/scrypt.php
@@ -44,12 +44,11 @@ abstract class Password
      *
      * @return int
      */
-    protected static strlen( $str ) {
+    protected static function strlen( $str ) {
         static $isShadowed = null;
 
         if ($isShadowed === null) {
             $isShadowed = extension_loaded('mbstring') &&
-                function_exists('mb_strlen') &&
                 ini_get('mbstring.func_overload') & 2;
         }
 


### PR DESCRIPTION
Fixed missing function keyword in strlen() function.
Also removed redundant function existence check.

Fixed #25
