### PR TITLE
Update Travis badge links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 PHP scrypt module
 =================
 
-[![Build Status](https://www.travis-ci.org/DomBlack/php-scrypt.png?branch=master)](https://www.travis-ci.org/DomBlack/php-scrypt)
+[![Build Status](https://travis-ci.org/DomBlack/php-scrypt.svg?branch=master)](https://travis-ci.org/DomBlack/php-scrypt)
 
 This is a PHP library providing a wrapper to [Colin Percival's scrypt implementation](http://www.tarsnap.com/scrypt.html). Scrypt is a key derivation function designed to be far more secure against hardware brute-force attacks than alternative functions such as PBKDF2 or bcrypt.
 


### PR DESCRIPTION
They were broken and now they are fixed - looks like Travis dropped the "www" part for https connections.
