### PR TITLE
Updates to have scrypt use PHP memory limits memory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_script:
   - ./configure --enable-scrypt
   - make all
 script: TEST_PHP_EXECUTABLE=$(which php) php -n
-    -d open_basedir= -d output_buffering=0 -d memory_limit=-1
+    -d open_basedir= -d output_buffering=0 -d memory_limit=512M
     run-tests.php -n
     -d extension_dir=modules -d extension=scrypt.so --show-diff
     tests

--- a/crypto/params.c
+++ b/crypto/params.c
@@ -37,18 +37,28 @@
 #include "zend_config.w32.h"
 #endif
 
+#include "php_globals.h"
+#include "php_variables.h"
+#include "php_getopt.h"
+#include "zend_builtin_functions.h"
+#include "zend_extensions.h"
+#include "zend_modules.h"
+#include "zend_globals.h"
+#include "zend_ini_scanner.h"
+#include "zend.h"
+#include "zend_alloc.h"
+#include "php_config.h"
+# include "TSRM.h"
+
+
 #include <errno.h>
 
 #include <stddef.h>
 
-#include "zend.h"
-#include "zend_alloc.h"
-#include <php_globals.h>
 #ifdef PHP_WIN32
 # include "win32/time.h"
 # include "win32/php_stdint.h"
 #else
-#include <php_config.h>
 # include <stdint.h>
 # include <unistd.h>
 #endif
@@ -60,9 +70,6 @@
 #endif
 #include <sys/types.h>
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
 #ifdef HAVE_SYS_PARAM_H
 #include <sys/param.h>
 #endif
@@ -334,7 +341,7 @@ memtouse(size_t maxmem, double maxmemfrac, size_t * memlimit)
     size_t memavail;
 
     /* Memory is constrained by PHP itself */
-    memlimit_min = PG(memory_limit) - zend_memory_usage(1);
+    memlimit_min = (PG(memory_limit) - (1 TSRMLS_CC))/1024;
     
     	/* Only use the specified fraction of the available memory. */
 	if ((maxmemfrac > 0.5) || (maxmemfrac == 0.0))
@@ -346,9 +353,9 @@ memtouse(size_t maxmem, double maxmemfrac, size_t * memlimit)
 		memavail = maxmem;
 
 	/* But always allow at least 1 MiB. */
-	if (memavail < 1048576)
+	if (memavail < 1048576/1024)
         {
-                memavail = 1048576;
+                memavail = 1048576/1024;
         }
 		
   

--- a/crypto/params.c
+++ b/crypto/params.c
@@ -27,6 +27,11 @@
  * online backup system.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+
 #include "php.h"
 #ifdef PHP_WIN32
 #include "zend_config.w32.h"
@@ -35,8 +40,8 @@
 #include <errno.h>
 
 #include <stddef.h>
+
 #include "zend.h"
-#include "zend_alloc.h"
 #include "zend_alloc.h"
 #include <php_globals.h>
 #ifdef PHP_WIN32
@@ -134,10 +139,6 @@ pickparams(size_t maxmem, double maxmemfrac, double maxtime,
         *p = (uint32_t)(maxrp) / *r;
     }
 
-#ifdef DEBUG
-    fprintf(stderr, "N = %zu r = %d p = %d\n",
-        (size_t)(1) << *logN, (int)(*r), (int)(*p));
-#endif
 
     /* Success! */
     return (0);
@@ -347,11 +348,9 @@ memtouse(size_t maxmem, double maxmemfrac, size_t * memlimit)
 	/* But always allow at least 1 MiB. */
 	if (memavail < 1048576)
         {
-                php_error_docref(NULL TSRMLS_CC, E_WARNING, "%lu not enough memory available for using scrypt.", (unsigned long) memavail);
                 memavail = 1048576;
         }
 		
-                 /* php_error_docref(NULL TSRMLS_CC, E_NOTICE, "scrypt configured to use %lu out of %lu memory.", (unsigned long) memavail, (unsigned long) memlimit_mins  ); */
   
     /* Return limit via the provided pointer. */
     *memlimit = memavail;

--- a/crypto/params.c
+++ b/crypto/params.c
@@ -27,11 +27,23 @@
  * online backup system.
  */
 
+#include "php.h"
+#ifdef PHP_WIN32
+#include "zend_config.w32.h"
+#endif
+
+#include <errno.h>
+
 #include <stddef.h>
+#include "zend.h"
+#include "zend_alloc.h"
+#include "zend_alloc.h"
+#include <php_globals.h>
 #ifdef PHP_WIN32
 # include "win32/time.h"
 # include "win32/php_stdint.h"
 #else
+#include <php_config.h>
 # include <stdint.h>
 # include <unistd.h>
 #endif
@@ -313,260 +325,34 @@ scryptenc_cpuperf(double * opps)
     return (0);
 }
 
-#ifdef HAVE_SYSCTL_HW_USERMEM
-static int
-memlimit_sysctl_hw_usermem(size_t * memlimit)
-{
-    int mib[2];
-    uint8_t usermembuf[8];
-    size_t usermemlen = 8;
-    uint64_t usermem;
-
-    /* Ask the kernel how much RAM we have. */
-    mib[0] = CTL_HW;
-    mib[1] = HW_USERMEM;
-    if (sysctl(mib, 2, usermembuf, &usermemlen, NULL, 0))
-        return (1);
-
-    /*
-     * Parse as either a uint64_t or a uint32_t based on the length of
-     * output the kernel reports having copied out.  It appears that all
-     * systems providing a sysctl interface for reading integers copy
-     * them out as system-endian values, so we don't need to worry about
-     * parsing them.
-     */
-    if (usermemlen == sizeof(uint64_t))
-        usermem = *(uint64_t *)usermembuf;
-    else if (usermemlen == sizeof(uint32_t))
-        usermem = *(uint32_t *)usermembuf;
-    else
-        return (1);
-
-    /* Return the sysctl value, but clamp to SIZE_MAX if necessary. */
-#if UINT64_MAX > SIZE_MAX
-    if (usermem > SIZE_MAX)
-        *memlimit = SIZE_MAX;
-    else
-        *memlimit = usermem;
-#else
-    *memlimit = usermem;
-#endif
-
-    /* Success! */
-    return (0);
-}
-#endif
-
-/* If we don't HAVE_STRUCT_SYSINFO, we can't use sysinfo. */
-#ifndef HAVE_STRUCT_SYSINFO
-#undef HAVE_SYSINFO
-#endif
-
-/* If we don't HAVE_STRUCT_SYSINFO_TOTALRAM, we can't use sysinfo. */
-#ifndef HAVE_STRUCT_SYSINFO_TOTALRAM
-#undef HAVE_SYSINFO
-#endif
-
-#ifdef HAVE_SYSINFO
-static int
-memlimit_sysinfo(size_t * memlimit)
-{
-    struct sysinfo info;
-    uint64_t totalmem;
-
-    /* Get information from the kernel. */
-    if (sysinfo(&info))
-        return (1);
-    totalmem = info.totalram;
-
-    /* If we're on a modern kernel, adjust based on mem_unit. */
-#ifdef HAVE_STRUCT_SYSINFO_MEM_UNIT
-    totalmem = totalmem * info.mem_unit;
-#endif
-
-    /* Return the value, but clamp to SIZE_MAX if necessary. */
-#if UINT64_MAX > SIZE_MAX
-    if (totalmem > SIZE_MAX)
-        *memlimit = SIZE_MAX;
-    else
-        *memlimit = totalmem;
-#else
-    *memlimit = totalmem;
-#endif
-
-    /* Success! */
-    return (0);
-}
-#endif /* HAVE_SYSINFO */
-
-#ifdef _WIN32
-static int
-memlimit_rlimit(size_t * memlimit)
-{
-        return (0);
-}
-#else
-static int
-memlimit_rlimit(size_t * memlimit)
-{
-    struct rlimit rl;
-    uint64_t memrlimit;
-
-    /* Find the least of... */
-    memrlimit = (uint64_t)(-1);
-
-    /* ... RLIMIT_AS... */
-#ifdef RLIMIT_AS
-    if (getrlimit(RLIMIT_AS, &rl))
-        return (1);
-    if ((rl.rlim_cur != RLIM_INFINITY) &&
-        ((uint64_t)rl.rlim_cur < memrlimit))
-        memrlimit = rl.rlim_cur;
-#endif
-
-#ifdef RLIMIT_DATA
-    /* ... RLIMIT_DATA... */
-    if (getrlimit(RLIMIT_DATA, &rl))
-        return (1);
-    if ((rl.rlim_cur != RLIM_INFINITY) &&
-        ((uint64_t)rl.rlim_cur < memrlimit))
-        memrlimit = rl.rlim_cur;
-#endif
-
-    /* ... and RLIMIT_RSS. */
-#ifdef RLIMIT_RSS
-    if (getrlimit(RLIMIT_RSS, &rl))
-        return (1);
-    if ((rl.rlim_cur != RLIM_INFINITY) &&
-        ((uint64_t)rl.rlim_cur < memrlimit))
-        memrlimit = rl.rlim_cur;
-#endif
-
-    /* Return the value, but clamp to SIZE_MAX if necessary. */
-#if UINT64_MAX > SIZE_MAX
-    if (memrlimit > SIZE_MAX)
-        *memlimit = SIZE_MAX;
-    else
-        *memlimit = memrlimit;
-#else
-    *memlimit = memrlimit;
-#endif
-
-    /* Success! */
-    return (0);
-}
-#endif
-
-#ifdef _SC_PHYS_PAGES
-
-/* Some systems define _SC_PAGESIZE instead of _SC_PAGE_SIZE. */
-#ifndef _SC_PAGE_SIZE
-#define _SC_PAGE_SIZE _SC_PAGESIZE
-#endif
-
-static int
-memlimit_sysconf(size_t * memlimit)
-{
-    long pagesize;
-    long physpages;
-    uint64_t totalmem;
-
-    /* Set errno to 0 in order to distinguish "no limit" from "error". */
-    errno = 0;
-
-    /* Read the two limits. */
-    if (((pagesize = sysconf(_SC_PAGE_SIZE)) == -1) ||
-        ((physpages = sysconf(_SC_PHYS_PAGES)) == -1)) {
-        /* Did an error occur? */
-        if (errno != 0)
-            return (1);
-
-        /* If not, there is no limit. */
-        totalmem = (uint64_t)(-1);
-    } else {
-        /* Compute the limit. */
-        totalmem = (uint64_t)(pagesize) * (uint64_t)(physpages);
-    }
-
-    /* Return the value, but clamp to SIZE_MAX if necessary. */
-#if UINT64_MAX > SIZE_MAX
-    if (totalmem > SIZE_MAX)
-        *memlimit = SIZE_MAX;
-    else
-        *memlimit = totalmem;
-#else
-    *memlimit = totalmem;
-#endif
-
-    /* Success! */
-    return (0);
-}
-#endif
 
 int
 memtouse(size_t maxmem, double maxmemfrac, size_t * memlimit)
 {
-    size_t sysctl_memlimit, sysinfo_memlimit, rlimit_memlimit;
-    size_t sysconf_memlimit;
     size_t memlimit_min;
     size_t memavail;
 
-    /* Get memory limits. */
-#ifdef HAVE_SYSCTL_HW_USERMEM
-    if (memlimit_sysctl_hw_usermem(&sysctl_memlimit))
-        return (1);
-#else
-    sysctl_memlimit = (size_t)(-1);
-#endif
-#ifdef HAVE_SYSINFO
-    if (memlimit_sysinfo(&sysinfo_memlimit))
-        return (1);
-#else
-    sysinfo_memlimit = (size_t)(-1);
-#endif
-    if (memlimit_rlimit(&rlimit_memlimit))
-        return (1);
-#ifdef _SC_PHYS_PAGES
-    if (memlimit_sysconf(&sysconf_memlimit))
-        return (1);
-#else
-    sysconf_memlimit = (size_t)(-1);
-#endif
+    /* Memory is constrained by PHP itself */
+    memlimit_min = PG(memory_limit) - zend_memory_usage(1);
+    
+    	/* Only use the specified fraction of the available memory. */
+	if ((maxmemfrac > 0.5) || (maxmemfrac == 0.0))
+		maxmemfrac = 0.5;
+	memavail = maxmemfrac * memlimit_min;
 
-#ifdef DEBUG
-    fprintf(stderr, "Memory limits are %zu %zu %zu %zu\n",
-        sysctl_memlimit, sysinfo_memlimit, rlimit_memlimit,
-        sysconf_memlimit);
-#endif
+	/* Don't use more than the specified maximum. */
+	if ((maxmem > 0) && (memavail > maxmem))
+		memavail = maxmem;
 
-    /* Find the smallest of them. */
-    memlimit_min = (size_t)(-1);
-    if (memlimit_min > sysctl_memlimit)
-        memlimit_min = sysctl_memlimit;
-    if (memlimit_min > sysinfo_memlimit)
-        memlimit_min = sysinfo_memlimit;
-    if (memlimit_min > rlimit_memlimit)
-        memlimit_min = rlimit_memlimit;
-    if (memlimit_min > sysconf_memlimit)
-        memlimit_min = sysconf_memlimit;
-
-    /* Only use the specified fraction of the available memory. */
-    if ((maxmemfrac > 0.5) || (maxmemfrac == 0.0))
-        maxmemfrac = 0.5;
-    memavail = maxmemfrac * memlimit_min;
-
-    /* Don't use more than the specified maximum. */
-    if ((maxmem > 0) && (memavail > maxmem))
-        memavail = maxmem;
-
-    /* But always allow at least 1 MiB. */
-    if (memavail < 1048576)
-        memavail = 1048576;
-
-#ifdef DEBUG
-    fprintf(stderr, "Allowing up to %zu memory to be used\n", memavail);
-#endif
-
+	/* But always allow at least 1 MiB. */
+	if (memavail < 1048576)
+        {
+                php_error_docref(NULL TSRMLS_CC, E_WARNING, "%lu not enough memory available for using scrypt.", (unsigned long) memavail);
+                memavail = 1048576;
+        }
+		
+                 /* php_error_docref(NULL TSRMLS_CC, E_NOTICE, "scrypt configured to use %lu out of %lu memory.", (unsigned long) memavail, (unsigned long) memlimit_mins  ); */
+  
     /* Return limit via the provided pointer. */
     *memlimit = memavail;
     return (0);

--- a/tests/params.phpt
+++ b/tests/params.phpt
@@ -2,6 +2,8 @@
 Test that the scrypt_pickparams() functions works.
 --SKIPIF--
 <?php if (!extension_loaded("scrypt")) print "skip"; ?>
+--INI--
+memory_limit=4G
 --FILE--
 <?php 
 echo gettype(scrypt_pickparams(1024, 0.75, 1000));

--- a/tests/params.phpt
+++ b/tests/params.phpt
@@ -3,10 +3,10 @@ Test that the scrypt_pickparams() functions works.
 --SKIPIF--
 <?php if (!extension_loaded("scrypt")) print "skip"; ?>
 --INI--
-memory_limit=4G
+memory_limit=2G
 --FILE--
 <?php 
-echo gettype(scrypt_pickparams(1024, 0.75, 1000));
+echo gettype(scrypt_pickparams(0, 0.75, 0));
 ?>
 --EXPECT--
 array

--- a/tests/vectors.phpt
+++ b/tests/vectors.phpt
@@ -3,7 +3,7 @@ Test scrypt KDF using test vectors.
 --SKIPIF--
 <?php if (!extension_loaded("scrypt")) print "skip"; ?>
 --INI--
-memory_limit=4G
+memory_limit=2G
 --FILE--
 <?php 
 echo scrypt("", "", 16, 1, 1, 64) . "\n";

--- a/tests/vectors.phpt
+++ b/tests/vectors.phpt
@@ -3,7 +3,7 @@ Test scrypt KDF using test vectors.
 --SKIPIF--
 <?php if (!extension_loaded("scrypt")) print "skip"; ?>
 --INI--
-memory_limit=2G
+memory_limit=4G
 --FILE--
 <?php 
 echo scrypt("", "", 16, 1, 1, 64) . "\n";


### PR DESCRIPTION
Giving this one a try on Travis.

Since memory allocation was moved to emalloc, I removed all the max memory checks in params.c that were to get some form of system memory.  Instead I replaced it with grabbing the current PHP max memory and subtracting the currently used memory.   Since BEST case scenario is for 50% of the memory to be used we can see if that is safe or not.
The pickparams test is probably going to fail since it doesn't have my changes in it:
gettype(scrypt_pickparams(1024, 0.75, 1000));

My limits code is working in raw bytes, wheras this seems to be expecting kB?  So either I need to update my code to convert bytes to K, or these numbers need to be made either much much larger or set to 0.

