### PR TITLE
Add GCC CFLAGS for SSE+SSE2 instruction set

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -23,6 +23,9 @@ if test $PHP_SCRYPT != "no"; then
 
     version=nosse
     AC_CHECK_HEADER([emmintrin.h], [version=sse], [version=nosse])
+    if test "$version" = "sse"; then
+        CFLAGS="$CFLAGS -msse -msse2"
+    fi
     AC_DEFINE(HAVE_SCRYPT, 1, [Whether you have scrypt])
     PHP_NEW_EXTENSION(scrypt, php_scrypt.c php_scrypt_utils.c crypto/sha256.c crypto/crypto_scrypt-$version.c crypto/params.c, $ext_shared)
 


### PR DESCRIPTION
Based on comment for gstreamer https://bugzilla.redhat.com/show_bug.cgi?id=1092991#c1

To build with GCC 4.9 you need to force it to use SSE instructions.