### PR TITLE
Changed RETURN_STRINGL parameters for PHP7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
 env:
   - REPORT_EXIT_STATUS=1
     NO_INTERACTION=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,5 @@
 language: php
 php:
-  - 5.2
-  - 5.3
-  - 5.4
-  - 5.5
-  - 5.6
   - 7.0
 env:
   - REPORT_EXIT_STATUS=1

--- a/php_scrypt.c
+++ b/php_scrypt.c
@@ -199,10 +199,10 @@ PHP_FUNCTION(scrypt)
         php_hash_bin2hex(hex, buf, keyLength);
         efree(buf);
         hex[keyLength*2] = '\0';
-        RETURN_STRINGL(hex, keyLength * 2, 0);
+        RETURN_STRINGL(hex, keyLength * 2);
     } else {
         buf[keyLength] = '\0';
-        RETURN_STRINGL((char *)buf, keyLength, 0);
+        RETURN_STRINGL((char *)buf, keyLength);
     }
 }
 /* }}} */


### PR DESCRIPTION
According to examples from https://wiki.php.net/phpng-upgrading

The new API is not backwards-compatible to the API for PHP5, so we have to omit PHP5 support. That shouldn't be a problem though, as we can have two branches like we already have.