### PR TITLE
nosse version needs to include php_scrypt.h as well

### DIFF
--- a/crypto/crypto_scrypt-nosse.c
+++ b/crypto/crypto_scrypt-nosse.c
@@ -45,6 +45,7 @@
 #include "sysendian.h"
 
 #include "crypto_scrypt.h"
+#include "php_scrypt.h"
 
 static void blkcpy(uint8_t *, uint8_t *, size_t);
 static void blkxor(uint8_t *, uint8_t *, size_t);


### PR DESCRIPTION
On FreeBSD 13, the package fails to build with PHP 8.0 even after applying the changes from #56. Adding the same include to an additional file fixes the build.