### PR TITLE
Increase minimum version requirement to PHP 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,14 @@
 language: php
 
-matrix:
-  include:
-    - php: 5.3
-      dist: precise
-      
 php:
-  - 5.4
-  - 5.5
-  - 5.6
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
+  - 7.4
+  - 8.0
+  - 8.1
+  - nightly
 
 env:
   - REPORT_EXIT_STATUS=1

--- a/package.xml
+++ b/package.xml
@@ -68,7 +68,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
  <dependencies>
   <required>
    <php>
-    <min>5.3</min>
+    <min>7.0</min>
    </php>
    <pearinstaller>
     <min>1.4.0</min>

--- a/php_scrypt.c
+++ b/php_scrypt.c
@@ -43,11 +43,7 @@
 
 #include "math.h"
 
-#if PHP_MAJOR_VERSION >= 7
 typedef size_t strsize_t;
-#else
-typedef int    strsize_t;
-#endif
 
 /* {{{ arginfo */
 ZEND_BEGIN_ARG_INFO_EX(scrypt_arginfo, 0, 0, 6)
@@ -212,20 +208,12 @@ PHP_FUNCTION(scrypt)
         php_hash_bin2hex(hex, buf, keyLength);
         efree(buf);
         hex[keyLength*2] = '\0';
-        #if PHP_MAJOR_VERSION >= 7
-            RETURN_STRINGL(hex, keyLength * 2);
-            efree(hex);
-        #else
-            RETURN_STRINGL(hex, keyLength * 2, 0);
-        #endif
+		RETURN_STRINGL(hex, keyLength * 2);
+		efree(hex);
     } else {
         buf[keyLength] = '\0';
-        #if PHP_MAJOR_VERSION >= 7
-            RETURN_STRINGL((char *)buf, keyLength);
-            efree(buf);
-        #else
-            RETURN_STRINGL((char *)buf, keyLength, 0);
-        #endif
+		RETURN_STRINGL((char *)buf, keyLength);
+		efree(buf);
     }
 }
 /* }}} */


### PR DESCRIPTION
This is for v2.0.0. We could also increase the version requirement more aggressively, but it seems that PHP 7.0 will be ok for now.