### PR TITLE
Check CPU architecture before attempting to enable SSE

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -22,14 +22,16 @@ if test $PHP_SCRYPT != "no"; then
     AC_CHECK_MEMBER([struct sysinfo.totalram], [AC_DEFINE(HAVE_STRUCT_SYSINFO_TOTALRAM)])
 
     version=nosse
-    if test "$(uname)" == 'Darwin'; then
-        sysctl -a | grep -iq "^machdep.cpu.features.\+sse2"
-    else
-        grep -iq "^flags.\+sse2" /proc/cpuinfo
-    fi
-    if test $? == 0; then
-        version=sse
-        CFLAGS="$CFLAGS -msse -msse2"
+    if test "$(uname -m)" == 'x86_64' || test "$(uname -m)" == 'i386' || test "$(uname -m)" == 'i686'; then
+        if test "$(uname)" == 'Darwin'; then
+            sysctl -a | grep -iq "^machdep.cpu.features.\+sse2"
+        else
+            grep -iq "^flags.\+sse2" /proc/cpuinfo
+        fi
+        if test $? == 0; then
+            version=sse
+            CFLAGS="$CFLAGS -msse -msse2"
+        fi
     fi
     AC_DEFINE(HAVE_SCRYPT, 1, [Whether you have scrypt])
     PHP_NEW_EXTENSION(scrypt, php_scrypt.c php_scrypt_utils.c crypto/sha256.c crypto/crypto_scrypt-$version.c crypto/params.c, $ext_shared)


### PR DESCRIPTION
This is a fix for #75 that makes sure that SSE isn't enabled on non x86 architectures.