### PR TITLE
Remove dependency on hash extension on 8.6

### DIFF
--- a/php_scrypt.c
+++ b/php_scrypt.c
@@ -58,10 +58,12 @@
 
 typedef size_t strsize_t;
 
+#if PHP_VERSION_ID < 80600
 static const zend_module_dep scrypt_deps[] = {
 	ZEND_MOD_REQUIRED("hash")
 	ZEND_MOD_END
 };
+#endif
 
 static PHP_MINIT_FUNCTION(scrypt)
 {
@@ -73,9 +75,13 @@ static PHP_MINIT_FUNCTION(scrypt)
 }
 
 zend_module_entry scrypt_module_entry = {
+#if PHP_VERSION_ID < 80600
 	STANDARD_MODULE_HEADER_EX,
 	NULL,
 	scrypt_deps,
+#else
+	STANDARD_MODULE_HEADER,
+#endif
 	PHP_SCRYPT_EXTNAME,
 	ext_functions,
 	PHP_MINIT(scrypt),


### PR DESCRIPTION
From UPGRADING.INTERNALS

```
  . The zend_parse_parameters_none_throw(), zend_parse_parameters_throw(),
    and ZEND_PARSE_PARAMS_THROW have been removed due to being misleading,
    since ZPP always throws, unless ZEND_PARSE_PARAMS_QUIET is given. Use
    the non-throw versions.

  . Added zend_bin2hex() and zend_bin2hex_str() as helper functions to remove
    dependencies on /ext/hash in various extensions.
```

And remove dependency on hash extension